### PR TITLE
feat(terraform) simplify by only support 1 role once

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,9 +1,4 @@
-output "roles" {
-  description = "IAM roles created mapping."
-  value       = {
-    for role_key, role in aws_iam_role.this : role_key => {
-      name = role.name
-      arn  = role.arn
-    }
-  }
+output "role_arn" {
+  description = "IAM role created"
+  value       = aws_iam_role.this.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,6 @@
 variable "bitbucket_openid_connect_provider_arn" {
-  type = string
+  type        = string
+  description = "The name of the workspace."
 }
 
 variable "bitbucket_workspace_name" {
@@ -7,15 +8,18 @@ variable "bitbucket_workspace_name" {
   description = "The name of the workspace."
 }
 
-variable "roles" {
-  default    = {}
-  type       = map(object({
-    name             = string
-    tags             = object({})
-    allowed_subjects = list(string)
-    policies         = map(object({
-      arn = string
-    }))
-  }))
-  description = "A map of roles to create. The roles will be exposed in the output with their same key. Allowed subjects will be matched against the sub claim and they can be specified with wildcard. More info about their format here: https://support.atlassian.com/bitbucket-cloud/docs/deploy-on-aws-using-bitbucket-pipelines-openid-connect/#Using-claims-in-ID-tokens-to-limit-access-to-the-IAM-role-in-AWS. inline_policies_json is a list of json strings to attach as inline policies."
+variable "allowed_subjects" {
+  type        = list(string)
+  description = "The list of the allowed subjects. You can get this value from Bitbucket Pipeline OpenId Connect page."
+}
+
+variable "role_name" {
+  type        = string
+  description = "The name of the iam role."
+}
+
+variable "policy_arns" {
+  type        = list(string)
+  default     = []
+  description = "The arns of policy you want to attach to the role."
 }


### PR DESCRIPTION
Create 1 role once. By doing so, we can simplify the module input and structure.