### PR TITLE
feat: support custom Kubernetes groups for EKS access entry (CP-782)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,123 @@
 
 Terraform module for create AWS IAM Role to support Bitbucket OIDC.
 
+## Usage
+
+### Upgrade to 3.4.0
+
+If you upgrade to `3.4.0` and do not set `eks_access_entry_kubernetes_groups`, the module behavior remains the same as previous versions.
+
+- when `eks_access_entry_scope = "namespace"`, the module still automatically adds `group-<namespace>-admin`
+- when no Kubernetes groups are produced, `kubernetes_groups` remains `null`
+
+This means existing consumers can upgrade without changing their configuration, and only opt in to the new behavior when extra Kubernetes RBAC groups are needed.
+
+### Add custom Kubernetes groups to EKS access entry
+
+From `3.4.0`, this module supports passing additional Kubernetes groups to the generated EKS access entry. This is useful when the CD role needs extra Kubernetes RBAC permissions beyond the default namespace admin groups.
+
+```hcl
+module "bitbucket_oidc_aws_role" {
+  source  = "shoplineapp/bitbucket-oidc-aws-role/shoplineapp"
+  version = "3.4.0"
+
+  bitbucket_openid_connect_provider_arn = aws_iam_openid_connect_provider.bitbucket.arn
+  bitbucket_workspace_name              = "shopline"
+  allowed_subjects                      = ["{repository_uuid}:{deployment_environment_uuid}:{step_uuid}"]
+  role_name                             = "example-cd-role"
+
+  eks_cluster_name       = "example-eks"
+  eks_cluster_namespaces = ["production"]
+
+  # Default namespace group `group-production-admin` will still be included.
+  eks_access_entry_kubernetes_groups = [
+    "ec2nc-manager",
+    "custom-deployer",
+  ]
+}
+```
+
+Behavior summary:
+
+- `eks_access_entry_scope = "namespace"`: automatically includes `group-<namespace>-admin`
+- `eks_access_entry_scope = "cluster"`: does not generate default namespace admin groups
+- `eks_access_entry_kubernetes_groups`: appends any custom groups you provide
+- duplicate group names are removed automatically
+
+Examples:
+
+#### Keep existing behavior after upgrading
+
+```hcl
+module "bitbucket_oidc_aws_role" {
+  source  = "shoplineapp/bitbucket-oidc-aws-role/shoplineapp"
+  version = "3.4.0"
+
+  eks_access_entry_scope = "namespace"
+  eks_cluster_namespaces = ["prod"]
+}
+```
+
+Result:
+
+```hcl
+["group-prod-admin"]
+```
+
+#### Use `eks_access_entry_scope` together with custom groups
+
+```hcl
+module "bitbucket_oidc_aws_role" {
+  source  = "shoplineapp/bitbucket-oidc-aws-role/shoplineapp"
+  version = "3.4.0"
+
+  eks_access_entry_scope = "namespace"
+  eks_cluster_namespaces = ["prod", "staging"]
+
+  eks_access_entry_kubernetes_groups = [
+    "ec2nc-manager",
+    "group-prod-admin",
+  ]
+}
+```
+
+Result:
+
+```hcl
+[
+  "group-prod-admin",
+  "group-staging-admin",
+  "ec2nc-manager",
+]
+```
+
+`group-prod-admin` is only kept once because duplicate group names are removed automatically.
+
+#### Cluster scope with custom groups only
+
+```hcl
+module "bitbucket_oidc_aws_role" {
+  source  = "shoplineapp/bitbucket-oidc-aws-role/shoplineapp"
+  version = "3.4.0"
+
+  eks_access_entry_scope = "cluster"
+
+  eks_access_entry_kubernetes_groups = [
+    "ec2nc-manager",
+    "custom-deployer",
+  ]
+}
+```
+
+Result:
+
+```hcl
+[
+  "ec2nc-manager",
+  "custom-deployer",
+]
+```
+
 ## Contribution guidelines
 
 1. Directly modify the tf code.

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "aws_eks_access_entry" "this" {
   principal_arn = aws_iam_role.this.arn
   # Use helm chart to create the group by default, please find the group name convention in helm chart repo.
   # ref: https://github.com/shoplineapp/helm-charts/blob/master/eks/templates/role_admin.yaml
-  kubernetes_groups = var.eks_access_entry_scope == "namespace" ? [for ns in var.eks_cluster_namespaces : "group-${ns}-admin"] : null
+  kubernetes_groups = length(local.eks_access_entry_kubernetes_groups) > 0 ? local.eks_access_entry_kubernetes_groups : null
   depends_on        = [time_sleep.aws_iam_role_propagation]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "eks_cluster_namespaces" {
   description = "The eks cluster namespace where you will deploy to"
 }
 
+variable "eks_access_entry_kubernetes_groups" {
+  type        = list(string)
+  default     = []
+  description = "Additional Kubernetes groups to associate with the EKS access entry."
+}
+
 variable "eks_access_entry_scope" {
   type        = string
   default     = "namespace"
@@ -91,4 +97,6 @@ locals {
     concat(var.eks_cluster_names, [var.eks_cluster_name]) :
     var.eks_cluster_names
   )
+  default_eks_access_entry_kubernetes_groups = var.eks_access_entry_scope == "namespace" ? [for ns in var.eks_cluster_namespaces : "group-${ns}-admin"] : []
+  eks_access_entry_kubernetes_groups         = distinct(concat(local.default_eks_access_entry_kubernetes_groups, var.eks_access_entry_kubernetes_groups))
 }


### PR DESCRIPTION
Allow additional Kubernetes RBAC groups to be attached to the generated EKS access entry while preserving existing namespace-based defaults. Update the module logic and README so consumers can extend access behavior in v3.4.0 without breaking current configurations

## Background

Pls refer to the https://shopline.atlassian.net/browse/CP-782

## Test

I use shiun-service repo to test

```hcl
module "cd_role_by_env" {
  depends_on = [data.aws_ecr_repository.shiun_service]
  source     = "/Users/shiun.chiu/GitHub/terraform-shoplineapp-bitbucket-oidc-aws-role"

 # ....

  eks_cluster_name                   = var.eks_cluster_name
  eks_cluster_namespaces             = [var.namespace]
  ecr_repo_name                      = data.aws_ecr_repository.shiun_service.name
  eks_access_entry_kubernetes_groups = ["k8s-shiun-test-new-group"] # I add this line
```

terraform plan

```shell
Terraform planned the following actions, but then encountered a problem:

  # module.cd_role_by_env.aws_eks_access_entry.this[0] will be updated in-place
  ~ resource "aws_eks_access_entry" "this" {
        id                = "shiun-service-test:arn:aws:iam::123123123:role/cd_shiun-service-test"
      ~ kubernetes_groups = [
          + "k8s-shiun-test-new-group",
            # (1 unchanged element hidden)
        ]
        tags              = {}
        # (8 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```